### PR TITLE
Fix script tab not closable after Python finishes

### DIFF
--- a/kame/script/xscriptingthreadconnector.cpp
+++ b/kame/script/xscriptingthreadconnector.cpp
@@ -76,7 +76,7 @@ XScriptingThreadConnector::XScriptingThreadConnector(
         m_lsnOnDefout = tr[ *scrthread].onMessageOut().connectWeakly(
             shared_from_this(), &XScriptingThreadConnector::onDefout, Listener::FLAG_MAIN_THREAD_CALL);
         m_lsnOnStatusChanged = tr[ *scrthread->status()].onValueChanged().connectWeakly(
-	        shared_from_this(), &XScriptingThreadConnector::onStatusChanged);
+	        shared_from_this(), &XScriptingThreadConnector::onStatusChanged, Listener::FLAG_MAIN_THREAD_CALL);
     });
     onStatusChanged(shot, scrthread->status().get());
 


### PR DESCRIPTION
## Summary

- `onStatusChanged` was connected without `FLAG_MAIN_THREAD_CALL`, causing it to run from the Python script thread when the script finishes
- This meant `m_pForm->m_closable` was written from a non-main thread without memory barriers (a real hazard on ARM/Apple Silicon), and Qt widget calls (`windowTitle`/`setWindowTitle`) were made from a non-main thread
- Adding `FLAG_MAIN_THREAD_CALL` ensures `onStatusChanged` always runs on the main thread via the existing `SignalBuffer` mechanism, making `m_closable` properly visible when `closeEvent` fires and keeping all Qt operations on the correct thread

https://claude.ai/code/session_01UUnwJW4Hrcfo9hz4uUX5Nq